### PR TITLE
fix lua stack for multiple devices

### DIFF
--- a/realsimgear.c
+++ b/realsimgear.c
@@ -132,7 +132,7 @@ static float loop_callback(
       action(cmdref);
     }
 
-    lua_pop(L, 2);
+    lua_pop(L, 1);
   }
 
   lua_settop(L, 0);


### PR DESCRIPTION
If using more than one device, the lua stack is invalid after the first iteration. This fix solves that problem. Also see issue #2.